### PR TITLE
Add simple validation to ProtectoraForm

### DIFF
--- a/src/components/ProtectoraForm.jsx
+++ b/src/components/ProtectoraForm.jsx
@@ -1,1 +1,48 @@
-export default function ProtectoraForm() { return <div>Formulario de protectora</div>; }
+import { useState } from 'react';
+
+export default function ProtectoraForm() {
+  const [nombre, setNombre] = useState('');
+  const [email, setEmail] = useState('');
+  const [errors, setErrors] = useState({});
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const newErrors = {};
+    if (!nombre) newErrors.nombre = 'El nombre es obligatorio';
+    if (!email) newErrors.email = 'El email es obligatorio';
+    setErrors(newErrors);
+    if (Object.keys(newErrors).length === 0) {
+      alert('Formulario enviado');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        <label>
+          Nombre:
+          <input
+            type="text"
+            value={nombre}
+            onChange={(e) => setNombre(e.target.value)}
+            required
+          />
+        </label>
+        {errors.nombre && <p style={{ color: 'red' }}>{errors.nombre}</p>}
+      </div>
+      <div>
+        <label>
+          Email:
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </label>
+        {errors.email && <p style={{ color: 'red' }}>{errors.email}</p>}
+      </div>
+      <button type="submit">Enviar</button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- add a small React form for protectora registration
- require `nombre` and `email` inputs and show basic error messages

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a421fbd48321854fdb38ed1bbb38