### PR TITLE
Add Trello-like board example

### DIFF
--- a/trello/index.html
+++ b/trello/index.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mini Trello</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      padding: 1rem;
+    }
+    .board {
+      display: flex;
+      gap: 1rem;
+    }
+    .column {
+      background: #f4f4f4;
+      padding: 0.5rem;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      width: 250px;
+    }
+    .task-list {
+      list-style: none;
+      padding: 0;
+      min-height: 150px;
+    }
+    .task {
+      background: #fff;
+      border: 1px solid #ddd;
+      border-radius: 4px;
+      padding: 0.5rem;
+      margin-bottom: 0.5rem;
+      cursor: grab;
+    }
+    .dragging {
+      opacity: 0.5;
+    }
+  </style>
+</head>
+<body>
+  <h1>Mini Trello</h1>
+  <div class="board">
+    <div class="column">
+      <h2>Por hacer</h2>
+      <ul id="todo" class="task-list"></ul>
+      <input id="task-input" type="text" placeholder="Nueva tarea" />
+      <button id="add-btn">Agregar</button>
+    </div>
+    <div class="column">
+      <h2>En progreso</h2>
+      <ul id="progress" class="task-list"></ul>
+    </div>
+    <div class="column">
+      <h2>Hecho</h2>
+      <ul id="done" class="task-list"></ul>
+    </div>
+  </div>
+  <script>
+    const input = document.getElementById('task-input');
+    const addBtn = document.getElementById('add-btn');
+    const todoList = document.getElementById('todo');
+    const lists = document.querySelectorAll('.task-list');
+
+    function addTask(text) {
+      const li = document.createElement('li');
+      li.textContent = text;
+      li.className = 'task';
+      li.draggable = true;
+      li.addEventListener('dragstart', () => li.classList.add('dragging'));
+      li.addEventListener('dragend', () => li.classList.remove('dragging'));
+      return li;
+    }
+
+    addBtn.addEventListener('click', () => {
+      const text = input.value.trim();
+      if (text) {
+        todoList.appendChild(addTask(text));
+        input.value = '';
+      }
+    });
+
+    lists.forEach(list => {
+      list.addEventListener('dragover', e => {
+        e.preventDefault();
+        const dragging = document.querySelector('.dragging');
+        if (dragging && e.target.classList.contains('task-list')) {
+          list.appendChild(dragging);
+        }
+      });
+      list.addEventListener('drop', e => {
+        e.preventDefault();
+        const dragging = document.querySelector('.dragging');
+        if (dragging) {
+          list.appendChild(dragging);
+        }
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone `trello/index.html` that provides a simple board with columns and draggable tasks

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6842dbde3734832180ee656e7475a6b0